### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ php:
     - 5.5
     - 5.6
     - 7.0
+    - 7.1
+    - 7.2
     - nightly
     - hhvm
+
+matrix:
+    allow_failures:
+        - php: nightly
 
 before_install:
     - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^5.4 || ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6"
+        "phpunit/phpunit": "^4.6|^5.5|^6.5|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/AssertEmailTest.php
+++ b/tests/AssertEmailTest.php
@@ -3,9 +3,9 @@
 namespace Tests\albertcolom\Assert;
 
 use albertcolom\Assert\AssertEmail;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class AssertEmailTest extends PHPUnit_Framework_TestCase
+class AssertEmailTest extends TestCase
 {
     /**
      * @test
@@ -122,5 +122,13 @@ class AssertEmailTest extends PHPUnit_Framework_TestCase
     public  function itShouldThrowInvalidArgumentExceptionWhenGetTemporalMail()
     {
         AssertEmail::temporalMail('test@yopmail.com');
+    }
+
+    /**
+     * @test
+     */
+    public  function itShouldReturnTrueOnValidEmailAddress()
+    {
+        $this->assertTrue(AssertEmail::temporalMail('peter279k@gmail.com'));
     }
 }


### PR DESCRIPTION
# Changed log
- Set the multiple PHPUnit versions for different PHP versions.
- Add more tests.
- Set the other PHP versions in Travis CI build.
- Add the ```allow_failures``` part to accept the ```php-nightly``` can be failed in Travis CI build.